### PR TITLE
include openaps/cli/* in MANIFEST to get setup.py to install it

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include openaps/cli/*

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='openaps',
     # url="https://github.com/openaps/openaps",
     url="https://openaps.org/",
     packages=['openaps'],
+    include_package_data = True,
     install_requires = [
       'pyserial', 'python-dateutil', 'argcomplete',
       'gitpython',


### PR DESCRIPTION
Fixes https://github.com/openaps/openaps/issues/1

Not sure if this is the best fix, so feel free to reject the PR and fix it properly, but it does work for me.  :-)