### PR TITLE
Adding medtronic commands to iterate glucose and history by hours

### DIFF
--- a/openaps/vendors/medtronic.py
+++ b/openaps/vendors/medtronic.py
@@ -360,7 +360,7 @@ class iter_glucose_hours (MedtronicTask):
   def get_params (self, args):
     params = dict(hours=float(args.hours))
 
-    if args.now is not None:
+    if 'now' in args and args.now is not None:
       params.update(now=args.now)
 
     return params
@@ -378,7 +378,7 @@ class iter_glucose_hours (MedtronicTask):
   def main (self, args, app):
     params = self.get_params(args)
     min_offset = relativedelta.relativedelta(hours=params['hours'])
-    min_timestamp = parse(json.load(argparse.FileType('r')(params['now']))) if 'now' in params else None
+    min_timestamp = parse(json.load(argparse.FileType('r')(params['now']))) - min_offset if 'now' in params else None
 
     records = [ ]
     for rec in self.range( ):


### PR DESCRIPTION
```
$ openaps use pump iter_glucose_hours -h
usage: openaps-use pump iter_glucose_hours [-h] [--now NOW] hours

 Read latest n hours of glucose data
  

positional arguments:
  hours       The number of hours of historical data to retrieve

optional arguments:
  -h, --help  show this help message and exit
  --now NOW   A read_clock report filename from which to offset the hours
```
```
$ openaps use pump iter_pump_hours -h
usage: openaps-use pump iter_pump_hours [-h] [--now NOW] hours

 Read latest n hours of pump records
  

positional arguments:
  hours       The number of hours of historical data to retrieve

optional arguments:
  -h, --help  show this help message and exit
  --now NOW   A read_clock report filename from which to offset the hours
```

### Examples:
#### Read the last 4 hours of glucose data, beginning from the latest records
```
$ openaps use pump iter_glucose_hours 4
```
#### Read the last 2.5 hours of history data prior to a specific clock value, beginning from the latest history
```
$ openaps use pump iter_pump_hours 2.5 --now clock.json
```