### PR TITLE
allow process shell to use json by default

### DIFF
--- a/bin/openaps
+++ b/bin/openaps
@@ -51,6 +51,11 @@ class BaseApp (cli.Base):
   Utilities for developing an artificial pancreas system.
   openaps helps you manage and structure reports for various devices.
 
+       .-. .,-.  .-. .--. .-.  .,-. .--.
+      (   )|   )(.-' |  |(   ) |   )`--.
+       `-' |`-'  `--''  `-`-'`-|`-' `--'
+           |                   |        
+           '                   '        
 Common workflows:
 
 Getting started:

--- a/openaps/reports/reporters/__init__.py
+++ b/openaps/reports/reporters/__init__.py
@@ -20,7 +20,7 @@ class Reporter (object):
   def no_op_serialize (self, data):
     return data
   def serialize (self, data):
-    name = 'prerender_' + self.report.fields['reporter']
+    name = 'prerender_' + self.report.fields['reporter'].lower( )
     render = getattr(self.task.method, name, self.no_op_serialize)
     return self.method.serialize(render(data), self)
   def __call__ (self, data):
@@ -29,7 +29,6 @@ class Reporter (object):
     self.close( )
   def close (self):
     getattr(self.method, 'close_output_stream', default_close_stream)(self)
-
 
 def get_reporter_map ( ):
   return dict([ (r.__name__.split('.').pop( ).lower( ), r) for r in get_reporters( ) ])

--- a/openaps/vendors/dexcom.py
+++ b/openaps/vendors/dexcom.py
@@ -54,7 +54,7 @@ class glucose (scan):
       ])
       out.append(' '.join(line))
     return "\n".join(out)
-  def prerender_JSON (self, data):
+  def prerender_json (self, data):
     """ since everything is a dict/strings/ints, we can pass thru to json """
     return data
   def main (self, args, app):

--- a/openaps/vendors/medtronic.py
+++ b/openaps/vendors/medtronic.py
@@ -114,7 +114,6 @@ class MedtronicTask (scan):
     return model
   def setup_medtronic (self):
     log = logging.getLogger(decocare.__name__)
-    print self.device
     level = getattr(logging, self.device.get('logLevel', 'WARN'))
     address = self.device.get('logAddress', '/dev/log')
     log.setLevel(level)

--- a/openaps/vendors/medtronic.py
+++ b/openaps/vendors/medtronic.py
@@ -81,13 +81,17 @@ class MedtronicTask (scan):
       out.update(**self.update_session_info(fields))
     else:
       out['expires'] = parse(expires)
-      out['model'] = self.get_model( )
+      out['model'] = self.device.get('model', None)
     return out
 
   def update_session_info (self, fields):
     out = { }
-    self.device.extra.add_option('expires', fields['expires'].isoformat( ))
-    self.device.extra.add_option('model', fields['model'])
+    uses_extra = self.device.get('extra', None)
+    config = self.device
+    if uses_extra:
+      config = self.device.extra
+    config.add_option('expires', fields['expires'].isoformat( ))
+    config.add_option('model', fields['model'])
     out['expires'] = fields['expires']
     out['model'] = fields['model']
     return out
@@ -108,7 +112,15 @@ class MedtronicTask (scan):
     return out
   def check_session (self, app):
     self.session = self.get_session_info( )
-    self.device.add_option('model', self.device.get('model', self.get_model( )))
+    model = self.device.get('model', None)
+    if model is None:
+      model = self.get_model( )
+    self.pump.setModel(number=self.device.get('model', ''))
+    uses_extra = self.device.get('extra', None)
+    config = self.device
+    if uses_extra:
+      config = self.device.extra
+    config.add_option('model', self.device.get('model', model))
   def get_model (self):
     model = self.pump.read_model( ).getData( )
     return model

--- a/openaps/vendors/process.py
+++ b/openaps/vendors/process.py
@@ -40,7 +40,8 @@ class shell (Use):
   """
   def get_params (self, args):
     self.fields = self.device.get('fields').strip( ).split(' ')
-    params = dict(remainder=args.remainder)
+    params = dict(remainder=getattr(args, 'remainder', [])
+                , json_default=getattr(args, 'json_default', True))
     for opt in self.fields:
       if opt:
         params[opt] = getattr(args, opt)
@@ -67,7 +68,8 @@ class shell (Use):
     command = [ info.get('cmd')
               ]
     command.extend(info.get('args').split(' '))
-    self.json_default = args.json_default
+    params = self.get_params(args)
+    self.json_default = params.get('json_default')
     for opt in self.fields:
       if opt:
         command.append(getattr(args, opt))

--- a/openaps/vendors/process.py
+++ b/openaps/vendors/process.py
@@ -6,6 +6,7 @@ import sys, os
 import shlex
 from subprocess import check_output, call, PIPE
 import subprocess
+import json
 
 import argparse
 from plugins.vendor import Vendor
@@ -45,7 +46,15 @@ class shell (Use):
         params[opt] = getattr(args, opt)
     return params
 
+  def prerender_json (self, data):
+    """ since everything is a dict/strings/ints, we can pass thru to json
+    """
+    if self.json_default:
+      return json.loads(data)
+    else:
+      return data
   def configure_app (self, app, parser):
+    parser.add_argument('--not-json-default', dest='json_default', default=True, action='store_false', help="When the process does not produce json.")
     self.fields = self.device.get('fields').strip( ).split(' ')
     for opt in self.fields:
       if opt:
@@ -58,6 +67,7 @@ class shell (Use):
     command = [ info.get('cmd')
               ]
     command.extend(info.get('args').split(' '))
+    self.json_default = args.json_default
     for opt in self.fields:
       if opt:
         command.append(getattr(args, opt))


### PR DESCRIPTION
This is a small change that makes the assumption that external `process` types are always using `json` over their stdout.  If that's not true, use the `--not-json-default` flag.

The change means the `--format` flag is now optional if the process uses stdout, the following are equivalent:

```
bewest@hither:~/Documents/foo$ openaps use  oref0  shell calculate-iob monitor/pump-history.json 02.diyps/profile.json monitor/clock.json 
{
  "bolusiob": 0, 
  "iob": 0, 
  "activity": 0
}

```

```
bewest@hither:~/Documents/foo$ openaps use --format text oref0  shell calculate-iob monitor/pump-history.json 02.diyps/profile.json monitor/clock.json 
{"iob":0,"activity":0,"bolusiob":0}
bewest@hither:~/Documents/foo$ 

```
