### PR TITLE
pass stdin from parent process

### DIFF
--- a/openaps/reports/invoke.py
+++ b/openaps/reports/invoke.py
@@ -44,4 +44,7 @@ def main (args, app):
     else:
         reporters.Reporter(report, device, task)(output)
         print('reporting', report.name)
-        repo.index.add([report.name])
+        repo.git.add([report.name])
+        # XXX: https://github.com/gitpython-developers/GitPython/issues/265o
+        # GitPython <  0.3.7, this can corrupt the index
+        # repo.index.add([report.name])

--- a/openaps/reports/invoke.py
+++ b/openaps/reports/invoke.py
@@ -40,6 +40,9 @@ def main (args, app):
         output = task.method(args, app)
     except Exception as e:
         print(report.name, ' raised ', e, file=sys.stderr)
+        # save prior progress in git
+        app.epilog( )
+        # ensure we still blow up with non-zero exit
         raise
     else:
         reporters.Reporter(report, device, task)(output)

--- a/openaps/vendors/process.py
+++ b/openaps/vendors/process.py
@@ -78,7 +78,7 @@ class shell (Use):
         command.append(getattr(args, opt))
     command.extend(getattr(args, 'remainder', []))
     command = shlex.split(' '.join(command))
-    proc = subprocess.Popen(command, stdin=PIPE, stdout=PIPE)
+    proc = subprocess.Popen(command, stdout=PIPE)
     output, stderr = proc.communicate( )
     # output = check_output(command, shell=True)
     return output


### PR DESCRIPTION
This allows devices to consume `-`/stdin as expected.

Critical for making stuff like this work:

`nightscout cull-latest-openaps-treatments monitor/pump-history-zoned.json $(openaps use latest-treatments shell |json created_at )  | openaps use  ns-upload shell treatments.json -`