### PR TITLE
try again to examine git corruption

### DIFF
--- a/openaps/cli/__init__.py
+++ b/openaps/cli/__init__.py
@@ -63,8 +63,8 @@ class ConfigApp (Base):
   def epilog (self):
     self.create_git_commit( )
   def git_repo (self):
-    from git import Repo
-    self.repo = getattr(self, 'repo', Repo(os.getcwd( )))
+    from git import Repo, GitCmdObjectDB
+    self.repo = getattr(self, 'repo', Repo(os.getcwd( ), odbt=GitCmdObjectDB))
     return self.repo
 
   def create_git_commit (self):
@@ -76,5 +76,8 @@ class ConfigApp (Base):
       TODO: better change descriptions
       {2:s}
       """.format(self.parser.prog, ' '.join(sys.argv[1:]), ' '.join(sys.argv))
-      git.commit('-avm', msg)
+      # https://github.com/gitpython-developers/GitPython/issues/265
+      # git.commit('-avm', msg)
+      self.repo.index.commit(msg)
+    self.repo.git.gc( )
 


### PR DESCRIPTION
Looking at some logs, it appears that people run out of inodes because of extra churn that gitpython is doing behind the scenes.

Docs: http://gitpython.readthedocs.org/en/stable/tutorial.html

* Try using GitCmdObjectDB, trade more memory for less time
  (maybe useful for more densely packed repos with lots of small objects?)
* Use IndexFile.commit instead of git.commit
* Run git gc, in attempt to clean up some of the churn