### PR TITLE
Fix oref0_glucose report on G5

### DIFF
--- a/openaps/vendors/dexcom.py
+++ b/openaps/vendors/dexcom.py
@@ -475,9 +475,7 @@ class oref0_glucose (glucose):
   def from_ini (self, fields):
     fields['glucose'] = none_from_ini(fields.get('glucose', None))
     fields['sensor'] = none_from_ini(fields.get('sensor', None))
-    fields['no_raw'] = False
-    if 'no_raw' in fields and fields.get('no_raw', 'True') == 'True':
-      fields['no_raw'] = True
+    fields['no_raw'] = 'no_raw' in fields and fields.get('no_raw', 'True') == 'True'
     fields = self.fill.from_ini(fields)
     return fields
 


### PR DESCRIPTION
I'm using a Dexcom G5 and started receiving an error after pulling the latest from `dev` for the following command:

```bash
$ openaps report invoke monitor/glucose-raw.json
```

This is the report from my `openaps.ini`:
```
[report "monitor/glucose-raw.json"]
count = 20
device = cgm
threshold = 100
use = oref0_glucose
reporter = JSON
hours = 2.0
no_raw = True
```

Here is the stack trace:
```
monitor/glucose-raw.json raised Python int too large to convert to C long
Traceback (most recent call last):
  File "/home/pi/openaps/openaps/openaps/reports/invoke.py", line 34, in main
    output = task.method(args, app)
  File "/home/pi/openaps/openaps/openaps/uses/use.py", line 45, in __call__
    output = self.main(args, app)
  File "/home/pi/openaps/openaps/openaps/vendors/dexcom.py", line 543, in main
    for egv, raw in itertools.izip_longest(iter_glucose, iter_sensor):
  File "/home/pi/openaps/dexcom_reader/dexcom_reader/readdata.py", line 300, in iter_records
    for x in reversed(xrange(start, end)):
OverflowError: Python int too large to convert to C long
```

Here is the breaking commit: https://github.com/openaps/openaps/commit/6fee307989bbfa3c18e60b762dce8c49e6b20506 (cc @bewest)

The fix seems straightforward enough (`fields['no_raw']` was always being set to `False`), but please let me know if I'm missing something or there's more that I'm not seeing.

Also, if someone could give this a quick sanity test on a G4, it would be appreciated! Thanks!