### PR TITLE
Add new radio_locale parameter for Medtronic pumps

### DIFF
--- a/openaps/vendors/medtronic.py
+++ b/openaps/vendors/medtronic.py
@@ -20,6 +20,7 @@ def configure_use_app (app, parser):
 
 def configure_add_app (app, parser):
   parser.add_argument('serial', nargs='?', default='')
+  parser.add_argument('radio_locale', nargs='?', default='US')
 
 def configure_app (app, parser):
   if app.parent.name == 'add':
@@ -661,7 +662,13 @@ class iter_pump_hours (iter_glucose_hours):
 
 
 def set_config (args, device):
+  if args.radio_locale:
+    radio_locale = args.radio_locale.upper( )
+  else:
+    radio_locale = 'US'
+
   device.add_option('serial', args.serial)
+  device.add_option('radio_locale', radio_locale)
 
 def display_device (device):
   return ''


### PR DESCRIPTION
Add support for the 'radio_locale' medtronic parameter.

This helps make using https://github.com/oskarpearson/mmeowlink/commit/3a8d8677497ad2217201b4f110083b6dbf89cd30 easier.