### PR TITLE
Adding G6 touchscreen receiver support

### DIFF
--- a/openaps/__init__.py
+++ b/openaps/__init__.py
@@ -7,5 +7,5 @@ Release notes:
           python environment.  Also, rely more on json import/export
           of configuration.  Also, variety of git tweaks.
 """
-__version__ = '0.2.1-dev'
+__version__ = '0.2.2-dev'
 

--- a/openaps/vendors/dexcom.py
+++ b/openaps/vendors/dexcom.py
@@ -37,10 +37,11 @@ class scan (Use):
     return readdata.Dexcom.FindDevice( )
   def before_main (self, args, app):
     self.port = self.scanner( )
-    # set model = G5 in config
-    model = self.device.get('model', 'G4').upper( )
+    # set model = G4, G5, or G6 in config
+    model = self.device.get('model', 'G4').upper()
     G5 = model == 'G5'
-    self.dexcom = self.port and readdata.GetDevice(self.port, G5=G5) or None
+    G6 = model == 'G6'
+    self.dexcom = self.port and readdata.GetDevice(self.port, G5=G5, G6=G6) or None
   def main (self, args, app):
     return self.port or ''
 
@@ -49,6 +50,7 @@ class config (Use):
   def configure_app (self, app, parser):
     parser.add_argument('-M', '--model', default=None)
     parser.add_argument('-5', '--G5', dest='model', const='G5', action='store_const', default=None)
+    parser.add_argument('-6', '--G6', dest='model', const='G6', action='store_const', default=None)
   def main (self, args, app):
     results = dict(**self.device.extra.fields)
     dirty = False

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='openaps',
     install_requires = [
       'pyserial', 'python-dateutil', 'argcomplete',
       'gitpython', 'mock', 'nose',
-      'decocare > 0.0.26', 'dexcom_reader >= 0.1.8'
+      'decocare > 0.0.26', 'dexcom_reader >= 0.1.11'
     ],
     dependency_links = [
       'http://github.com/openaps/dexcom_reader/tarball/master#egg=dexcom_reader-master',


### PR DESCRIPTION
Passes down whether this is a G4, G5, or G6 receiver in the form of a pair of booleans during Dexcom class instantiation.

**Must merge https://github.com/openaps/dexcom_reader/pull/19 into dexcom_receiver before adding this or it breaks support for the receivers all together.**