### PR TITLE
Pin mock dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='openaps',
     include_package_data = True,
     install_requires = [
       'pyserial', 'python-dateutil', 'argcomplete',
-      'gitpython <= 2.1.11', 'mock', 'nose',
+      'gitpython <= 2.1.11', 'mock <= 3.0.5', 'nose',
       'decocare > 0.0.26', 'dexcom_reader >= 0.1.8'
     ],
     dependency_links = [

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='openaps',
     include_package_data = True,
     install_requires = [
       'pyserial', 'python-dateutil', 'argcomplete',
+      'zipp <= 1.2.0',
       'gitpython <= 2.1.11', 'mock <= 3.0.5', 'nose',
       'decocare > 0.0.26', 'dexcom_reader >= 0.1.8'
     ],


### PR DESCRIPTION
This patch pins mock to version <= 3.0.5, as the 4.x.x versions are requiring python 3.